### PR TITLE
Fix nextId() not throw RangeError

### DIFF
--- a/incstr.js
+++ b/incstr.js
@@ -35,7 +35,7 @@ incstr.idGenerator = function ({ lastId = '',
   const maxDigit = alphabet.length - 1
   function nextId () {
     for (var i = digs.length - 1; i >= 0; i--) { // !!! var not let
-      if (digs[i] === -1) throw new RangeError(`Character "${str[i]}" is not in the alphabet "${alph}"`)
+      if (digs[i] === -1) throw new RangeError(`Character "${lastId[i]}" is not in the alphabet "${alphabet}"`)
       if (digs[i] === maxDigit) {
         digs[i] = 0
         continue

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ describe('incstr()', () => {
     expect(incstr('111', '01', true)).to.equal('1000')
   })
   it('incstr("cc", "ab") throws', () => {
-    expect(incstr.bind(incstr, 'cc', 'ab')).to.throw(RangeError)
+    expect(incstr.bind(incstr, 'cc', 'ab')).to.throw(RangeError, 'Character "c" is not')
   })
 })
 
@@ -42,6 +42,6 @@ describe('nextId = incstr.idGenerator(opts)', () => {
   it('nextId() throws if opts={lastId:"cc",alphabet:"ab"}', () => {
     let nextId = incstr.idGenerator({ lastId: "cc", alphabet: "ab" });
 
-    expect(nextId).to.throw(RangeError);
+    expect(nextId).to.throw(RangeError, 'Character "c" is not');
   });
 })

--- a/test/test.js
+++ b/test/test.js
@@ -39,4 +39,9 @@ describe('nextId = incstr.idGenerator(opts)', () => {
     let nextId = incstr.idGenerator({lastId: 'cc', alphabet: 'abc'})
     expect(nextId()).to.equal('aaa')
   })
+  it('nextId() throws if opts={lastId:"cc",alphabet:"ab"}', () => {
+    let nextId = incstr.idGenerator({ lastId: "cc", alphabet: "ab" });
+
+    expect(nextId).to.throw(RangeError);
+  });
 })


### PR DESCRIPTION
undefined variable `str` referenced  in code.

[incstr/incstr\.js at master · anatol\-grabowski/incstr](https://github.com/anatol-grabowski/incstr/blob/master/incstr.js#L38)

and test result.

```
  1) nextId = incstr.idGenerator(opts)
       nextId() throws if opts={lastId:"cc",alphabet:"ab"}:

      AssertionError: expected [Function nextId] to throw 'RangeError' but 'ReferenceError: str is not defined' was thrown
      + expected - actual

      -ReferenceError: str is not defined
      +RangeError

      at Context.<anonymous> (test/test.js:45:28)
```